### PR TITLE
Fixup linux I40e netmap driver compilation error in earlier Linux ver…

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -2275,6 +2275,17 @@ EOF
 		return test_and_set_bit(1, &pf->state);
 	}
 EOF
+
+   add_test 'define I40E_CLEAN_PROGRAMMING_STATE_ACCEPT_QWORD' <<EOF
+	#include "i40e/i40e.h"
+	#include "i40e/i40e_txrx_common.h"
+	#pragma GCC diagnostic error "-Wint-conversion"
+
+	void
+	dummy(struct i40e_ring *rx_ring, union i40e_rx_desc *rx_desc, u64 qw) {
+		(void)!i40e_clean_programming_status(rx_ring, rx_desc, qw);
+	}
+EOF
   fi # i40e
 
   if drv enabled igb; then

--- a/LINUX/i40e_netmap_linux.h
+++ b/LINUX/i40e_netmap_linux.h
@@ -563,7 +563,7 @@ i40e_netmap_rxsync(struct netmap_kring *kring, int flags)
 				complete = 0;
 			}
 
-			if (unlikely(i40e_rx_is_programming_status(qword))) {
+			if (unlikely(qword & I40E_RXD_QW1_LENGTH_SPH_MASK)) {
 				/* Clean programming status and skip over nic and ring
 				 * slots. To shelter the application from
 				 * this we would need to rotate the
@@ -573,7 +573,11 @@ i40e_netmap_rxsync(struct netmap_kring *kring, int flags)
 				 * Notes that when the i40e is cleaning programming
 				 * status the size is zero anyway.
 				 */
+#ifdef I40E_CLEAN_PROGRAMMING_STATE_ACCEPT_QWORD
 				i40e_clean_programming_status(rxr, curr->raw.qword[0], qword);
+#else
+				i40e_clean_programming_status(rxr, curr, qword);
+#endif
 				complete = 1;
 				ring->slot[nm_i].len = 0;
 				nm_i = nm_next(nm_i, lim);


### PR DESCRIPTION
…sions

Two compilation error fixes for earlier Linux versions:
- Use qword1 & I40E_RXD_QW1_LENGTH_SPH_MASK directly rather than
  i40e_rx_is_programming_status() to avoid relying it as earlier Linux
  versions declear it as static in i40e_txrx.c rather than
  i40e_txrs_common.h.
- Define I40E_CLEAN_PROGRAMMING_STATE_ACCEPT_QWORD in configure to
  discern between different versions of i40e_clean_programming_status()