### PR TITLE
Make sure skbs that need fragmenting have dst info set

### DIFF
--- a/LINUX/ipt_netmap/ipt_netmap.c
+++ b/LINUX/ipt_netmap/ipt_netmap.c
@@ -718,6 +718,14 @@ static unsigned int nmring_tg4(struct sk_buff *skb,
 		return NF_STOLEN;
 	}
 	else if (skb->len > mtu) {
+		/* Need destination to be able to fragment the packet */
+		if (!skb_dst(skb)) {
+			ipt_ipv4_route(priv->net, skb);
+			if (!skb_dst(skb)) {
+				IP_INC_STATS(priv->net, IPSTATS_MIB_FRAGFAILS);
+				return NF_DROP;
+			}
+		}
 		if ((iph->frag_off & htons(IP_DF)) == 0) {
 			ip_do_fragment(priv->net, NULL, skb, copy_pkt_to_queue);
 		}


### PR DESCRIPTION
When tunnel security reprocessing is enabled, skb's arrive without
the skb_dst info set. This works ok for pkts that fit the mtu
determined in nmring_tg4(). However, if the packet is bigger it will
be sent to ip_do_fragment() and that assumes skb_dst is set and
de-references it, leading to a crash.

NAT being enabled seems to play a part - at least with the configuration
in the CR. I will do some more investigating to work out how this
impacts the problem.

Now, if the packet is going to be fragmented and skb_dst is not set
ipt_ipv4_route() is called to set it. A route lookup is costly so this
may not be the best solution?? However, I don't understand the code
well enough to suggest something else.

I'll de-AW+-afy this commit message once reviewed :)