### PR TITLE
ipt_netmap: Fix incorrect return NULL

### DIFF
--- a/LINUX/ipt_netmap/ipt_netmap.c
+++ b/LINUX/ipt_netmap/ipt_netmap.c
@@ -916,7 +916,6 @@ static void __net_exit ipt_netmap_net_exit(struct net *net)
 		}
 	}
 #endif
-	return NULL;
 }
 
 static struct pernet_operations ipt_netmap_net_ops = {


### PR DESCRIPTION
This function isn't meant to return anything.