### PR TITLE
Set ring sizes using RX ring parameters only.

### DIFF
--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -878,6 +878,13 @@ netmap_krings_create(struct netmap_adapter *na, u_int tailroom)
 	 */
 	for_rx_tx(t) {
 		ndesc = nma_get_ndesc(na, t);
+#ifdef ATL_CHANGE
+		/**
+		* The ARX900S by default has more than 1024 TX slots.
+		* To mitigate this, use the number of RX slots for both TX/RX.
+		*/
+		ndesc = nma_get_ndesc(na, NR_RX);
+#endif
 		for (i = 0; i < n[t]; i++) {
 			kring = NMR(na, t)[i];
 			bzero(kring, sizeof(*kring));

--- a/sys/dev/netmap/netmap_generic.c
+++ b/sys/dev/netmap/netmap_generic.c
@@ -1106,6 +1106,18 @@ generic_netmap_attach(struct ifnet *ifp)
 		return EINVAL;
 	}
 
+#ifdef ATL_CHANGE
+	/**
+	* The Octeon TX2 by default has a minimum 4096 TX slots.
+	* To mitigate this, use the generic size.
+	*/
+	if (num_tx_desc > netmap_generic_ringsize)
+		num_tx_desc = netmap_generic_ringsize;
+
+	if (num_rx_desc > netmap_generic_ringsize)
+		num_rx_desc = netmap_generic_ringsize;
+#endif
+
 	gna = nm_os_malloc(sizeof(*gna));
 	if (gna == NULL) {
 		nm_prerr("no memory on attach, give up");


### PR DESCRIPTION
The ARX900S has a minimum of 4096 TX ring slots, which is larger than the 1024 max which netmap allows. As the eth driver does not allow to reduce this number, the number of krings created for TX will be matched with the RX, which for the ARX is 256.