### PR TITLE
Fix generic netmap driver for oversize HW rings

### DIFF
--- a/sys/dev/netmap/netmap_generic.c
+++ b/sys/dev/netmap/netmap_generic.c
@@ -1106,6 +1106,17 @@ generic_netmap_attach(struct ifnet *ifp)
 		return EINVAL;
 	}
 
+#ifdef ATL_CHANGE
+	/**
+	* For oversized rings, use the generic parameters.
+	*/
+	if (num_tx_desc > netmap_generic_ringsize)
+		num_tx_desc = netmap_generic_ringsize;
+
+	if (num_rx_desc > netmap_generic_ringsize)
+		num_rx_desc = netmap_generic_ringsize;
+#endif
+
 	gna = nm_os_malloc(sizeof(*gna));
 	if (gna == NULL) {
 		nm_prerr("no memory on attach, give up");


### PR DESCRIPTION
Devices can have ring parameters which are larger than the max which netmap allows. To mitigate this we now use the generic_ring_size parameter, instead of the HW ring size parameter in the case of oversized HW rings.