### PR TITLE
Update for 6.1.27 linux kernel

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -1845,6 +1845,30 @@ EOF
 	};
 EOF
 
+# check for net_device->stats using u64_stats_t instead of integer
+  add_test 'have DEV_TSTATS_U64_STATS_T' <<EOF
+    #include <linux/netdevice.h>
+
+    void * dummy(struct net_device *dev)
+    {
+     struct pcpu_sw_netstats *tstats = this_cpu_ptr(dev->tstats);
+     u64_stats_add(&tstats->rx_packets, 1);
+     u64_stats_add(&tstats->rx_bytes, 1);
+     return tstats;
+    }
+EOF
+
+# check if old version of netif_rx exists that doesn't handle soft irqs
+  add_test 'have NETIF_RX_NO_SOFTIRQ' <<EOF
+    #include <linux/netdevice.h>
+
+    void * dummy(struct sk_buff *skb)
+    {
+     netif_rx_ni(skb);
+     return m;
+    }
+EOF
+
   #####################################################
   # checks related to drivers                         #
   #####################################################
@@ -2302,6 +2326,21 @@ EOF
 	}
 EOF
   fi # i40e
+  
+ if drv enabled ice; then
+    add_test 'have ICE_XRINGS' <<EOF
+	#include "ice/ice.h"
+
+	struct ice_tx_ring *
+	dummy1(struct ice_vsi *vsi) {
+		return vsi->tx_rings[0];
+	}
+	struct ice_rx_ring *
+	dummy2(struct ice_vsi *vsi) {
+		return vsi->rx_rings[0];
+	}
+EOF
+  fi # ice
 
   if drv enabled igb; then
     add_test 'have IGB_RD32' <<EOF

--- a/LINUX/final-patches/vanilla--ice--00000--99999
+++ b/LINUX/final-patches/vanilla--ice--00000--99999
@@ -1,10 +1,10 @@
 diff --git a/ice/ice_base.c b/ice/ice_base.c
-index b43752e..9fe1540 100644
+index e864634d66bc..6fd0dbc293f7 100644
 --- a/ice/ice_base.c
 +++ b/ice/ice_base.c
-@@ -6,6 +6,11 @@
- #include "ice_base.h"
+@@ -7,6 +7,11 @@
  #include "ice_dcb_lib.h"
+ #include "ice_sriov.h"
  
 +#if defined(CONFIG_NETMAP) || defined(CONFIG_NETMAP_MODULE)
 +#define NETMAP_ICE_BASE
@@ -14,7 +14,7 @@ index b43752e..9fe1540 100644
  /**
   * __ice_vsi_get_qs_contig - Assign a contiguous chunk of queues to VSI
   * @qs_cfg: gathered variables needed for PF->VSI queues assignment
-@@ -461,6 +466,10 @@ static int ice_setup_rx_ctx(struct ice_ring *ring)
+@@ -448,6 +453,10 @@ static int ice_setup_rx_ctx(struct ice_rx_ring *ring)
  	/* Rx queue threshold in units of 64 */
  	rlan_ctx.lrxqthresh = 1;
  
@@ -25,7 +25,8 @@ index b43752e..9fe1540 100644
  	/* Enable Flexible Descriptors in the queue context which
  	 * allows this driver to select a specific receive descriptor format
  	 * increasing context priority to pick up profile ID; default is 0x01;
-@@ -617,5 +626,10 @@ int ice_vsi_cfg_rxq(struct ice_ring *ring)
+@@ -564,6 +573,11 @@ int ice_vsi_cfg_rxq(struct ice_rx_ring *ring)
+ 
  		return 0;
  	}
 +    
@@ -36,7 +37,7 @@ index b43752e..9fe1540 100644
  
  	ice_alloc_rx_bufs(ring, num_bufs);
  
-@@ -765,6 +779,10 @@ ice_vsi_cfg_txq(struct ice_vsi *vsi, struct ice_ring *ring,
+@@ -830,6 +844,10 @@ ice_vsi_cfg_txq(struct ice_vsi *vsi, struct ice_tx_ring *ring,
  	txq = &qg_buf->txqs[0];
  	if (pf_q == le16_to_cpu(txq->txq_id))
  		ring->txq_teid = le32_to_cpu(txq->q_teid);
@@ -48,10 +49,10 @@ index b43752e..9fe1540 100644
  	return 0;
  }
 diff --git a/ice/ice_main.c b/ice/ice_main.c
-index 6aaddd0..7af2de9 100644
+index cfc57cfc46e4..ac1eaad2b5a1 100644
 --- a/ice/ice_main.c
 +++ b/ice/ice_main.c
-@@ -33,6 +33,11 @@ MODULE_DESCRIPTION(DRV_SUMMARY);
+@@ -36,6 +36,11 @@ MODULE_DESCRIPTION(DRV_SUMMARY);
  MODULE_LICENSE("GPL v2");
  MODULE_FIRMWARE(ICE_DDP_PKG_FILE);
  
@@ -63,18 +64,7 @@ index 6aaddd0..7af2de9 100644
  static int debug = -1;
  module_param(debug, int, 0644);
  #ifndef CONFIG_DYNAMIC_DEBUG
-@@ -4550,7 +4555,9 @@ ice_probe(struct pci_dev *pdev, const struct pci_device_id __always_unused *ent)
- 	} else {
- 		dev_warn(dev, "RDMA is not supported on this device\n");
- 	}
--
-+#ifdef DEV_NETMAP
-+	ice_netmap_attach(pf);
-+#endif
- 	return 0;
- 
- err_init_aux_unroll:
-@@ -4650,7 +4657,9 @@ static void ice_remove(struct pci_dev *pdev)
+@@ -5061,7 +5066,9 @@ static void ice_remove(struct pci_dev *pdev)
  {
  	struct ice_pf *pf = pci_get_drvdata(pdev);
  	int i;
@@ -82,14 +72,25 @@ index 6aaddd0..7af2de9 100644
 +#ifdef DEV_NETMAP
 +	ice_netmap_detach(pf);
 +#endif /* DEV_NETMAP */
+ 	ice_devlink_unregister(pf);
  	for (i = 0; i < ICE_MAX_RESET_WAIT; i++) {
  		if (!ice_is_reset_in_progress(pf->state))
- 			break;
+@@ -5203,7 +5210,9 @@ static int ice_reinit_interrupt_scheme(struct ice_pf *pf)
+ 			ret);
+ 		goto err_reinit;
+ 	}
+-
++#ifdef DEV_NETMAP
++	ice_netmap_attach(pf);
++#endif
+ 	return 0;
+ 
+ err_reinit:
 diff --git a/ice/ice_txrx.c b/ice/ice_txrx.c
-index a094aec..020b7ae 100644
+index dbe80e5053a8..b65e5810dc2c 100644
 --- a/ice/ice_txrx.c
 +++ b/ice/ice_txrx.c
-@@ -18,6 +18,10 @@
+@@ -23,6 +23,10 @@
  #define FDIR_DESC_RXDID 0x40
  #define ICE_FDIR_CLEAN_DELAY 10
  
@@ -100,30 +101,31 @@ index a094aec..020b7ae 100644
  /**
   * ice_prgm_fdir_fltr - Program a Flow Director filter
   * @vsi: VSI to send dummy packet
-@@ -209,5 +213,9 @@ static bool ice_clean_tx_irq(struct ice_ring *tx_ring, int napi_budget)
- 	s16 i = tx_ring->next_to_clean;
- 	struct ice_tx_desc *tx_desc;
- 	struct ice_tx_buf *tx_buf;
-+#ifdef DEV_NETMAP
-+    if (tx_ring->netdev && netmap_tx_irq(tx_ring->netdev, tx_ring->q_index) != NM_IRQ_PASS)
-+        return true;
-+#endif /* DEV_NETMAP */
- 
- 	tx_buf = &tx_ring->tx_buf[i];
-@@ -1070,5 +1077,16 @@ int ice_clean_rx_irq(struct ice_ring *rx_ring, int budget)
+@@ -1120,6 +1124,16 @@ int ice_clean_rx_irq(struct ice_rx_ring *rx_ring, int budget)
  	struct xdp_buff xdp;
  	bool failure;
  
 +#ifdef DEV_NETMAP
-+    if (rx_ring->netdev) {
-+        int dummy, nm_irq;
-+        nm_irq = netmap_rx_irq(rx_ring->netdev, rx_ring->q_index, &dummy);
-+        if (nm_irq != NM_IRQ_PASS) {
-+            return 1;
-+        }
-+    }
++	if (rx_ring->netdev) {
++		int dummy, nm_irq;
++		nm_irq = netmap_rx_irq(rx_ring->netdev, rx_ring->q_index, &dummy);
++		if (nm_irq != NM_IRQ_PASS) {
++			return 1;
++		}
++	}
 +#endif /* DEV_NETMAP */
-+
 +
  	/* Frame size depend on rx_ring setup when PAGE_SIZE=4K */
  #if (PAGE_SIZE < 8192)
+ 	frame_sz = ice_rx_frame_truesize(rx_ring, 0);
+@@ -2447,6 +2461,10 @@ void ice_clean_ctrl_tx_irq(struct ice_tx_ring *tx_ring)
+ 	int budget = ICE_DFLT_IRQ_WORK;
+ 	struct ice_tx_desc *tx_desc;
+ 	struct ice_tx_buf *tx_buf;
++#ifdef DEV_NETMAP
++    if (tx_ring->netdev && netmap_tx_irq(tx_ring->netdev, tx_ring->q_index) != NM_IRQ_PASS)
++        return;
++#endif /* DEV_NETMAP */
+ 
+ 	tx_buf = &tx_ring->tx_buf[i];
+ 	tx_desc = ICE_TX_DESC(tx_ring, i);

--- a/LINUX/ice_netmap_linux.h
+++ b/LINUX/ice_netmap_linux.h
@@ -1,6 +1,14 @@
 #include <bsd_glue.h>
 #include <net/netmap.h>
 #include <dev/netmap/netmap_kern.h>
+#ifdef NETMAP_LINUX_HAVE_ICE_XRINGS
+#define NM_ICE_RXRING ice_rx_ring
+#define NM_ICE_TXRING ice_tx_ring
+#else
+#define NM_ICE_RXRING ice_ring
+#define NM_ICE_TXRING ice_ring
+#endif /* NETMAP_LINUX_HAVE_ICE_XRINGS */
+
 
 extern int ix_crcstrip;
 
@@ -53,7 +61,7 @@ ice_netmap_txsync(struct netmap_kring *kring, int flags)
 	/* device-specific */
 	struct ice_netdev_priv *np = netdev_priv(ifp);
 	struct ice_vsi *vsi = np->vsi;
-	struct ice_ring *txr;
+	struct NM_ICE_TXRING *txr;
 
 	if (!netif_carrier_ok(ifp))
 		return 0;
@@ -225,7 +233,7 @@ ice_netmap_rxsync(struct netmap_kring *kring, int flags)
 	/* device-specific */
 	struct ice_netdev_priv *np = netdev_priv(ifp);
 	struct ice_vsi *vsi = np->vsi;
-	struct ice_ring *rxr;
+	struct NM_ICE_RXRING *rxr;
 
 	if (!netif_running(ifp))
 		return 0;
@@ -505,7 +513,7 @@ SYSCTL_INT(_dev_netmap, OID_AUTO, ix_crcstrip,
 		CTLFLAG_RW, &ix_crcstrip, 1, "NIC strips CRC on rx frames");
 
 static void
-ice_netmap_configure_tx_ring(struct ice_ring *ring)
+ice_netmap_configure_tx_ring(struct NM_ICE_TXRING *ring)
 {
 	struct netmap_adapter *na;
 
@@ -519,7 +527,7 @@ ice_netmap_configure_tx_ring(struct ice_ring *ring)
 }
 
 static void
-ice_netmap_preconfigure_rx_ring(struct ice_ring *ring,
+ice_netmap_preconfigure_rx_ring(struct NM_ICE_RXRING *ring,
 		struct ice_rlan_ctx *rx_ctx)
 {
 	struct netmap_adapter *na;
@@ -540,7 +548,7 @@ ice_netmap_preconfigure_rx_ring(struct ice_ring *ring,
 }
 
 static int
-ice_netmap_configure_rx_ring(struct ice_ring *ring)
+ice_netmap_configure_rx_ring(struct NM_ICE_RXRING *ring)
 {
 	struct netmap_adapter *na;
 	struct netmap_slot *slot;

--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -422,7 +422,11 @@ nm_os_send_up(struct ifnet *ifp, struct mbuf *m, struct mbuf *prev)
 	(void)ifp;
 	(void)prev;
 	m->priority = NM_MAGIC_PRIORITY_RX; /* do not reinject to netmap */
+#ifdef NETMAP_LINUX_HAVE_NETIF_RX_NO_SOFTIRQ
 	netif_rx_ni(m);
+#else /* NETMAP_LINUX_HAVE_NETIF_RX_NO_SOFTIRQ */
+	netif_rx(m);
+#endif /* NETMAP_LINUX_HAVE_NETIF_RX_NO_SOFTIRQ */
 	return NULL;
 }
 

--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -1233,8 +1233,13 @@ netmap_grab_packets(struct netmap_kring *kring, struct mbq *q, int force)
 			{
 				struct pcpu_sw_netstats *tstats = this_cpu_ptr(dev->tstats);
 				u64_stats_update_begin(&tstats->syncp);
+#ifdef NETMAP_LINUX_HAVE_DEV_TSTATS_U64_STATS_T
+				u64_stats_add(&tstats->rx_packets, 1);
+				u64_stats_add(&tstats->rx_bytes, slot->len);
+#else /* NETMAP_LINUX_HAVE_DEV_TSTATS_U64_STATS_T */
 				tstats->rx_packets++;
 				tstats->rx_bytes += slot->len;
+#endif /* NETMAP_LINUX_HAVE_DEV_TSTATS_U64_STATS_T */
 				u64_stats_update_end(&tstats->syncp);
 			}
 		}


### PR DESCRIPTION
* Regenerate the vanilla-ice patch since the one from the atl tarball did not properly apply and needed changes for upstream.
* Update ice_netmap_linux.h for a type change. Upstream has some more changes but these have been skipped.
* Update netmap_linux.c for a function removal.
* Update netmap.c for a type change.
* Add configure tests so that netmap can support building between newer and older kernels with these code changes.