### PR TITLE
ipt_netmap: Add header file for skb_gso_segment

### DIFF
--- a/LINUX/ipt_netmap/ipt_netmap.c
+++ b/LINUX/ipt_netmap/ipt_netmap.c
@@ -24,6 +24,7 @@
 #include <net/xfrm.h>
 #include <linux/list.h>
 #include <net/icmp.h>
+#include <net/gso.h>
 #include "ipt_netmap.h"
 
 MODULE_LICENSE("GPL");


### PR DESCRIPTION
skb_gso_segment prototype declaration has moved into a new file, the linux 6.6 kernel. Include this file to continue building ipt_netmap.