### PR TITLE
Fix NETIF_RX_NO_SOFTIRQ detection

### DIFF
--- a/LINUX/configure
+++ b/LINUX/configure
@@ -1862,10 +1862,9 @@ EOF
   add_test 'have NETIF_RX_NO_SOFTIRQ' <<EOF
     #include <linux/netdevice.h>
 
-    void * dummy(struct sk_buff *skb)
+    void dummy(struct sk_buff *skb)
     {
      netif_rx_ni(skb);
-     return m;
     }
 EOF
 


### PR DESCRIPTION
An error in the configure file code snippet for detecting netif_rx_ni was causing netmap to use netif_rx on all platforms. This introduces up to 10ms of latency.

Fix the snippet by moving it closer to the upstream code.