### PR TITLE
ipt_netmap: Allow building for kernel < 6.4.1 but > 6.0.0

### DIFF
--- a/LINUX/ipt_netmap/ipt_netmap.c
+++ b/LINUX/ipt_netmap/ipt_netmap.c
@@ -24,7 +24,7 @@
 #include <net/xfrm.h>
 #include <linux/list.h>
 #include <net/icmp.h>
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,0,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,4,1)
 #include <net/gso.h>
 #endif
 #include "ipt_netmap.h"


### PR DESCRIPTION
net/gso.h was first created for 6.4.1, so need to fix up the conditional include so it builds for kernels < 6.4.1 but > 6.0.0.