### PR TITLE
Add locking to NIOCTXSYNC and NIOCRXSYNC ioctl

### DIFF
--- a/sys/dev/netmap/netmap.c
+++ b/sys/dev/netmap/netmap.c
@@ -3172,7 +3172,9 @@ netmap_ioctl(struct netmap_priv_d *priv, u_long cmd, caddr_t data,
 		}
 		mb(); /* make sure following reads are not from cache */
 
+		NMG_LOCK();
 		if (unlikely(priv->np_csb_atok_base)) {
+			NMG_UNLOCK();
 			nm_prerr("Invalid sync in CSB mode");
 			error = EBUSY;
 			break;
@@ -3229,6 +3231,7 @@ netmap_ioctl(struct netmap_priv_d *priv, u_long cmd, caddr_t data,
 		if (mbq_peek(&q)) {
 			netmap_send_up(na->ifp, &q);
 		}
+		NMG_UNLOCK();
 
 		break;
 	}


### PR DESCRIPTION
A crash can occur if rx/txsync is happening at the same time as the rings are being released.

The NIOCTXSYNC and NIOCRXSYNC ioctls should be within locks as the functions they call may access data that will be under contention.