### PR TITLE
mvpp2: set rx offset using queue id

### DIFF
--- a/LINUX/mvpp2_netmap.h
+++ b/LINUX/mvpp2_netmap.h
@@ -475,10 +475,11 @@ static void mvpp2_netmap_start(struct netmap_adapter *na)
 
 	/* Use netmap BM pools for this port */
 	for (i = 0; i < port->nrxqs; i++) {
-		mvpp2_rxq_drop_pkts(port, port->rxqs[i]);
+		struct mvpp2_rx_queue *rxq = port->rxqs[i];
+		mvpp2_rxq_drop_pkts(port, rxq);
 		mvpp2_rxq_short_pool_set(port, i, MVPP2_NETMAP_BMPOOL_FIRST + i);
 		mvpp2_rxq_long_pool_set(port, i, MVPP2_NETMAP_BMPOOL_FIRST + i);
-		mvpp2_rxq_offset_set(port, i, NETMAP_SLOT_HEADROOM);
+		mvpp2_rxq_offset_set(port, rxq->id, NETMAP_SLOT_HEADROOM);
 	}
 
 	/* Re-enable ingress if interface was running */


### PR DESCRIPTION
If multiple ports are used on the same CP unit, the queue number for these are separated by 32 i.e. queue 0 on port 0 is q0, but queue 0 on port 1 is q32. Therefore the offset set code does not work for these ports, as it tries to set q0-3 on each port instead of the correct queue ids.