### PR TITLE
Qualcomm support

### DIFF
--- a/LINUX/netmap_linux.c
+++ b/LINUX/netmap_linux.c
@@ -710,7 +710,11 @@ static unsigned int netmap_hook(void *priv,
 					const struct nf_hook_state *state)
 {
 	int ret = linux_generic_rx_handler_common(skb);
+#ifdef CONFIG_ARCH_QCOM
+	return likely(ret == NM_RX_HANDLER_STOLEN) ? NF_DROP : NF_ACCEPT;
+#else
 	return likely(ret == NM_RX_HANDLER_STOLEN) ? NF_STOLEN : NF_ACCEPT;
+#endif
 }
 #elif defined(NETMAP_LINUX_HAVE_RX_REGISTER)
 #ifdef NETMAP_LINUX_HAVE_RX_HANDLER_RESULT

--- a/sys/dev/netmap/netmap_generic.c
+++ b/sys/dev/netmap/netmap_generic.c
@@ -830,6 +830,13 @@ generic_rx_handler(if_t ifp, struct mbuf *m)
 		return 0;
 	}
 
+#ifdef CONFIG_ARCH_QCOM
+	/* Take a copy of this skb - the Qualcomm driver frees it before we are done (even if
+	 * we say we stole it / are dropping it).
+	 */
+	m = skb_copy(m, GFP_ATOMIC);
+#endif
+
 	/* limit the size of the queue */
 	if (unlikely(!gna->rxsg && MBUF_LEN(m) > NETMAP_BUF_SIZE(na))) {
 		/* This may happen when GRO/LRO features are enabled for


### PR DESCRIPTION
Adds:

* Return NF_DROP rather than NF_STOLEN that the qualcom driver doesn't handle properly.
* Copy packet in RX handling - the driver seems to free the skb after returning from our handling.