### PR TITLE
Fix TX stall when skipping netmapemu qdisc

### DIFF
--- a/sys/dev/netmap/netmap_generic.c
+++ b/sys/dev/netmap/netmap_generic.c
@@ -387,6 +387,16 @@ generic_netmap_register(struct netmap_adapter *na, int enable)
 			nm_prerr("nm_os_catch_tx(1) failed (%d)", error);
 			goto catch_rx;
 		}
+	#else
+		/* The custom qdisc and generic_ndo_start_xmit are not
+		 * installed, so NM_MAGIC_PRIORITY_TX on mbufs is never reset
+		 * by the driver. MBUF_QUEUED() would therefore always return
+		 * true, preventing generic_netmap_tx_clean() from reclaiming
+		 * TX slots and eventually stalling all TX traffic. Use the
+		 * refcount-based clean path instead (txqdisc=0), which works
+		 * correctly without the custom ndo_start_xmit hook.
+		 */
+		gna->txqdisc = 0;
 	#endif
 
 		na->na_flags |= NAF_NETMAP_ON;


### PR DESCRIPTION
Commit 6d072ad3b73a ("Prevent tc configs from applying for generic netmap adapter") skipped calling nm_os_catch_tx() to avoid installing the custom netmapemu qdisc and hooking ndo_start_xmit(). However, gna->txqdisc is still set to 1 by nm_os_generic_set_features so the tx sync path expects the qdisc to still be enabled.

Normally every mbuf sent by nm_os_generic_xmit_frame() is marked with NM_MAGIC_PRIORITY_TX and generic_ndo_start_xmit() resets that priority to 0 once the real driver transmits the packet.
Without the hook installed, the priority is never cleared. generic_netmap_tx_clean() checks MBUF_QUEUED() to decide if a slot is free and with txqdisc=1 and the priority permanently set, every slot appears as in-use and the TX ring fills up and traffic stops.

To fix this, turn off the txqdisc flag if we are skipping qdisc setup.