### PR TITLE
vmxnet3: fix four bugs in vmxnet3 netmap integration

### DIFF
--- a/LINUX/final-patches/vanilla--vmxnet3--60600--99999
+++ b/LINUX/final-patches/vanilla--vmxnet3--60600--99999
@@ -16,15 +16,17 @@ index 0578864792b6..be17a491faff
  static void
  vmxnet3_unmap_tx_buf(struct vmxnet3_tx_buf_info *tbi,
  		     struct pci_dev *pdev)
-@@ -408,6 +413,13 @@ vmxnet3_tq_tx_complete(struct vmxnet3_tx_queue *tq,
+@@ -408,6 +413,15 @@ vmxnet3_tq_tx_complete(struct vmxnet3_tx_queue *tq,
  	xdp_frame_bulk_init(&bq);
  	rcu_read_lock();
  
 +#ifdef DEV_NETMAP
 +	struct net_device *netdev = adapter->netdev;
 +
-+	if (netmap_tx_irq(netdev, tq - adapter->tx_queue) != NM_IRQ_PASS)
++	if (netmap_tx_irq(netdev, tq - adapter->tx_queue) != NM_IRQ_PASS) {
++		rcu_read_unlock();
 +		return 0;
++	}
 +#endif
 +
  	gdesc = tq->comp_ring.base + tq->comp_ring.next2proc;

--- a/LINUX/if_vmxnet3_netmap_v2.h
+++ b/LINUX/if_vmxnet3_netmap_v2.h
@@ -39,16 +39,14 @@ vmxnet3_netmap_reg(struct netmap_adapter *na, int onoff)
 		nm_clear_native_flags(na);
 	}
 
-	err = vmxnet3_rq_create_all(adapter);
-	if (err)
-		goto out;
-
 	if (netif_running(adapter->netdev)) {
+		err = vmxnet3_rq_create_all(adapter);
+		if (err)
+			goto out;
+
 		err = vmxnet3_activate_dev(adapter);
 		if (err)
 			goto out;
-	} else {
-		vmxnet3_reset_dev(adapter);
 	}
 
 out:
@@ -58,7 +56,7 @@ out:
 		vmxnet3_force_close(adapter);
 	}
 
-	return 0;
+	return err;
 }
 
 static u_int
@@ -228,6 +226,9 @@ vmxnet3_netmap_rxsync(struct netmap_kring *kring, int flags)
 	struct vmxnet3_cmd_ring *cmd_ring = rq->rx_ring;
 
 	if (!netif_carrier_ok(ifp))
+		return 0;
+
+	if (!rq->comp_ring.base)
 		return 0;
 
 	if (head > lim)


### PR DESCRIPTION
 1. Guard vmxnet3_netmap_rxsync against NULL comp_ring.base

    netif_carrier_ok() and netif_running() are independent flags in vmxnet3.  The hypervisor can assert carrier via a link-change interrupt before the interface is administratively up, so vmxnet3_netmap_rxsync() could pass the existing carrier check and then dereference a NULL comp_ring.base.  Add an explicit NULL guard before accessing the completion ring.

 2. Skip ring allocation when !netif_running in vmxnet3_netmap_reg

    When NIOCREGIF is called on an interface that has not yet been opened, ring sizes are zero.  Calling vmxnet3_rq_create_all() in this state passes size=0 to dma_alloc_coherent(), which on 6.12+ triggers WARN_ON(order >= MAX_ORDER) and a kernel panic.  Skip ring create/activate entirely when !netif_running; vmxnet3_open() will call vmxnet3_activate_dev() (and therefore vmxnet3_netmap_init_buffers()) when the interface is brought up.

 3. Propagate error return from vmxnet3_netmap_reg

    vmxnet3_netmap_reg() always returned 0, even on failure.  If vmxnet3_activate_dev() fails the error path calls vmxnet3_force_close() which destroys the rings via vmxnet3_rq_destroy_all(), setting comp_ring.base to NULL.  With the function still returning 0 netmap considered registration successful and the receive thread would crash in vmxnet3_netmap_rxsync(). Fix: return err instead of 0.

 4. Release RCU read lock before early return in vmxnet3_tq_tx_complete

    The DEV_NETMAP early-exit path returned without calling rcu_read_unlock(), leaking the read-side lock acquired immediately before.  Add rcu_read_unlock() before the return.

Assisted-by: GitHub-Copilot:claude-4.6-Sonnet