### PR TITLE
vmxnet3: Use better check for buffers not initialised

### DIFF
--- a/LINUX/if_vmxnet3_netmap_v2.h
+++ b/LINUX/if_vmxnet3_netmap_v2.h
@@ -228,7 +228,7 @@ vmxnet3_netmap_rxsync(struct netmap_kring *kring, int flags)
 	if (!netif_carrier_ok(ifp))
 		return 0;
 
-	if (!rq->comp_ring.base)
+	if (test_bit(VMXNET3_STATE_BIT_QUIESCED, &adapter->state))
 		return 0;
 
 	if (head > lim)


### PR DESCRIPTION
The previous fix checked for the completion pool being allocated. However there are other parts of the setup that might not have been completed yet. Clearing the VMXNET3_STATE_BIT_QUIESCED bit is the last thing the driver does during setup so it is safer to check that to determine if everything is ready to go.